### PR TITLE
put mid-line on top of text in `draw_logo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com).
 
+## 0.3.1
+
+### Changed
+- Put the mid-line on logo plots from `draw_logo` with negative values on top of text.
+
 ## 0.3.0
 
 ### Added

--- a/dmslogo/__init__.py
+++ b/dmslogo/__init__.py
@@ -15,7 +15,7 @@ into the package namespace:
 
 __author__ = 'Jesse Bloom'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 __url__ = 'https://github.com/jbloomlab/dmslogo'
 
 from dmslogo.facet import facet_plot  # noqa: F401

--- a/dmslogo/logo.py
+++ b/dmslogo/logo.py
@@ -470,7 +470,7 @@ def draw_logo(data,
 
     # draw line at zero
     if line_at_zero:
-        ax.axhline(y=0, ls='-', color='black', lw=1)
+        ax.axhline(y=0, ls='-', color='black', lw=1, zorder=4)
 
     return fig, ax
 


### PR DESCRIPTION
The mid-line created by `draw_logo` with negative values
sometimes ends up a bit *under* text. Now it is set to
be on top of text.

Also incremented version to 0.3.1.