### PR TITLE
remove deprecated `pkg_resources`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: install python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: install package and dependencies
         run: pip install -e . && pip install -r test_requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 ### Fixed
 - Removed deprecated `pkg_resources`, which was root of [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/212#event-22715605282)
 
+- Updated tests to use Python 3.13 and so they pass with the newer versions of `pandas`.
+
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com).
 
+## 0.7.1
+
+### Fixed
+- Removed deprecated `pkg_resources`, which was root of [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/212#event-22715605282)
+
+
 ## 0.7.0
 
 ### Fixed

--- a/dmslogo/__init__.py
+++ b/dmslogo/__init__.py
@@ -15,7 +15,7 @@ into the package namespace:
 
 __author__ = "Jesse Bloom"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __url__ = "https://github.com/jbloomlab/dmslogo"
 
 from dmslogo.facet import facet_plot  # noqa: F401

--- a/dmslogo/colorschemes.py
+++ b/dmslogo/colorschemes.py
@@ -6,12 +6,10 @@ colorschemes
 Color schemes.
 """
 
-
 import matplotlib.colors
 import matplotlib.pyplot as plt
 
 import numpy
-
 
 #: color-blind safe palette with gray, from
 #: http://bconnelly.net/2013/10/creating-colorblind-friendly-figures

--- a/dmslogo/facet.py
+++ b/dmslogo/facet.py
@@ -6,7 +6,6 @@ facet
 Facet multiple plots on the same figure.
 """
 
-
 import collections
 import operator
 

--- a/dmslogo/line.py
+++ b/dmslogo/line.py
@@ -6,7 +6,6 @@ line
 Draw line plots of site-level properties.
 """
 
-
 import matplotlib.pyplot as plt
 import matplotlib.ticker
 

--- a/dmslogo/logo.py
+++ b/dmslogo/logo.py
@@ -9,8 +9,8 @@ Some of this code is borrowed and modified from
 `pyseqlogo <https://github.com/saketkc/pyseqlogo>`_.
 """
 
-
 import glob
+import importlib.resources
 import os
 import warnings
 
@@ -24,17 +24,17 @@ import numpy
 
 import pandas as pd
 
-import pkg_resources
-
 import dmslogo.colorschemes
 import dmslogo.utils
-
 
 # default font
 _DEFAULT_FONT = "DejaVuSansMonoBold_SeqLogo"
 
 # add fonts to font manager
-_FONT_PATH = pkg_resources.resource_filename("dmslogo", "ttf_fonts/")
+with importlib.resources.as_file(
+    importlib.resources.files("dmslogo").joinpath("ttf_fonts")
+) as font_path:
+    _FONT_PATH = str(font_path)
 if not os.path.isdir(_FONT_PATH):
     raise RuntimeError(f"Cannot find font directory {_FONT_PATH}")
 

--- a/dmslogo/logo.py
+++ b/dmslogo/logo.py
@@ -367,8 +367,8 @@ def draw_logo(
         ylabel = letter_height_col
 
     # check letters are all upper case
-    letters = str(data[letter_col].unique())
-    if letters.upper() != letters:
+    letters = data[letter_col].unique()
+    if not all(str(letter) == str(letter).upper() for letter in letters):
         raise ValueError("letters in `letter_col` must be uppercase")
 
     # checks on input data

--- a/dmslogo/utils.py
+++ b/dmslogo/utils.py
@@ -65,21 +65,21 @@ class AxLimSetter:
 
     >>> data = [0.5, 0.6, 0.4, 0.4, 0.3, 0.5]
     >>> setter_default = AxLimSetter()
-    >>> setter_default.get_lims(data)
+    >>> tuple(float(v) for v in setter_default.get_lims(data))
     (-0.03, 0.63)
 
     Now use the `max_from_quantile` option to set an upper limit
     that substantially exceeds the "noise" of the all-similar values:
 
     >>> setter_max_quantile = AxLimSetter(max_from_quantile=(0.5, 0.05))
-    >>> setter_max_quantile.get_lims(data)
+    >>> tuple(float(v) for v in setter_max_quantile.get_lims(data))
     (-0.45, 9.45)
 
     Demonstrate `min_upperlim`:
 
     >>> setter_min_upperlim = AxLimSetter(max_from_quantile=(0.5, 0.05),
     ...                                   min_upperlim=10)
-    >>> setter_min_upperlim.get_lims(data)
+    >>> tuple(float(v) for v in setter_min_upperlim.get_lims(data))
     (-0.45, 10.0)
 
     """

--- a/dmslogo/utils.py
+++ b/dmslogo/utils.py
@@ -6,7 +6,6 @@ utils
 Utility functions for plotting.
 """
 
-
 import matplotlib.pyplot as plt
 import matplotlib.ticker
 

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 
 # conda dependencies
 dependencies:
-  - python==3.7
+  - python==3.13
   - pip
   # install the current package with `pip install .`
   - pip:

--- a/nbval_sanitize.cfg
+++ b/nbval_sanitize.cfg
@@ -9,3 +9,17 @@ replace: <cell_header_start>
 [pandas_cell_header_end]
 regex: </t[hd]>
 replace: <cell_header_end>
+
+# pandas 3 displays None where pandas 2 displayed NaN for missing string values
+[pandas_nan_none_html]
+regex: <cell_header_start>NaN<cell_header_end>
+replace: <cell_header_start>None<cell_header_end>
+
+[pandas_nan_none_text]
+regex: \bNaN\b
+replace: None
+
+# normalize runs of 2+ spaces to single space for text/plain DataFrame alignment
+[pandas_whitespace]
+regex: [ ][ ]+
+replace: SANITIZED_SPACE

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-select = [
+lint.select = [
   "E",   # pycodestyle
   "F",   # pyflakes
   "UP",  # pyupgrade
@@ -12,7 +12,7 @@ extend-exclude = [
     "notebooks",
     ".*",
 ]
-ignore = [
+lint.ignore = [
     "D203",
     "D205",
     "D212",


### PR DESCRIPTION
Removed deprecated `pkg_resources`, which was root of [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/212#event-22715605282)

Becomes version 0.7.1